### PR TITLE
media queries for ipad pro and iphone

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,11 +66,12 @@
         </div>
       </div>
       <div class="content">
-        <div class="news-title">News</div>
+      <div class="announcements-container">  
+        <div class="announcements-title">News</div>
         <div class="announcements">
           <div class="announcements-left">
             <img
-              class="announcement-images"
+              class="announcements-images"
               src="assets/lunar-dragon.jpg"
               alt="Lunar New Years Animal - Dragon"
               height="315px"
@@ -81,7 +82,7 @@
           </div>
           <div class="announcements-right">
             <img
-              class="announcement-images"
+              class="announcements-images"
               src="assets/freeTutor.jpeg"
               alt="Free Tutoring Service"
               height="315px"
@@ -91,7 +92,9 @@
             <div>Monday - Thursday: 5:30-7:30 PM EST</div>
           </div>
         </div>
+      </div> 
         <div class="separator-top long"></div>
+      <div class="schedule-container"> 
         <div class="schedule-title">Weekly Schedule</div>
         <div class="description">
           The Buddha Blessed Temple offers public meditation instruction,
@@ -133,24 +136,25 @@
           </div>
         </div>
       </div>
+      </div>
       <div class="locations">
         <div class="locations-container">
-          <div>
+          <div class="indiana">
             <span class="location-title">Tu Viện Vạn Phật Đảnh</span><br />
             3600 Mathis Road<br />
             Corydon, IN 47112
           </div>
-          <div>
+          <div class="kentucky">
             <span class="location-title">Tu Viện Vạn Phật Đảnh II</span><br />
             7748 Third Street Road<br />
             Louisville, KY 40214
           </div>
-          <div>
+          <div class="texas">
             <span class="location-title">Chùa Phật Giác</span><br />
             10022 Gaines Road<br />
             Sugar Land, TX 77498
           </div>
-          <div>
+          <div class="new-jersey">
             <span class="location-title">Chùa Phật Tâm</span><br />
             6310 Reega Ave.<br />
             Egg Harbor Twp, NJ 08234

--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,7 @@ body {
   grid-template-columns: 20% 60% 20%;
   grid-template-rows: 0.01fr .5fr;
   margin: 0% 10%;
+  height: 95vh;
 }
 
 .banner {
@@ -124,7 +125,13 @@ body {
   text-align: center;
 }
 
-.news-title {
+.announcements-container {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 1rem;
+  }
+
+.announcements-title {
   font-size: 50px;
   display: inline-block;
   font-weight: bolder;
@@ -161,7 +168,7 @@ body {
   width: 50%;
 }
 
-.announcement-images {
+.announcements-images {
   width: 90%;
 }
 
@@ -183,6 +190,12 @@ body {
   margin-right: auto;
   margin-left: auto;
   width: 90%;
+}
+
+.schedule-container {
+  display: flex;
+  flex-direction: column;
+  padding-top: .5rem; 
 }
 
 .schedule-title {
@@ -235,6 +248,8 @@ body {
 }
 
 .locations {
+  min-height: 950px;
+  padding: 1%;
   background-image: url(assets/floral-frost.jpg);
   background-repeat: repeat;
 }
@@ -242,10 +257,9 @@ body {
 .locations-container {
   display: flex;
   flex-direction: column;
+  /*
   justify-content: space-evenly;
-  padding: 1%;
-  height: 50%;
-
+  */
   font-size: 1.2rem;
   text-align: center;
   color: blue;
@@ -259,4 +273,83 @@ body {
 .tele-contact {
   color: red;
   font-weight: bold;
+}
+
+.indiana {
+  padding-top: .5rem;
+  padding-bottom: 2.5rem;
+}
+.kentucky {
+  padding-bottom: 2.5rem;
+}
+.texas {
+  padding-bottom: 2.5rem;
+}
+.new-jersey {
+  padding-bottom: 2rem;
+}
+
+@media (max-width: 475px) {
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    margin: 0%;
+  }
+  .banner {
+    grid-column-start: 2;
+    grid-column-end: 3;
+  }
+  .left-panel {
+    display: none;
+  }
+  .locations {
+    display: none;
+  }
+  .content {
+    font-size: 0.9rem;
+    height: 95vh;
+    background-repeat: repeat;
+  }
+  .announcements-images {
+    width: 75%;
+    height: 75%;
+  }
+  .announcements-title {
+    font-size: 35px;
+  }
+  .schedule-title {
+    font-size: 35px;
+  }
+  .announcements-container {
+    padding-bottom: 1rem;
+  }
+}
+
+@media (max-width: 835px) {
+  .left-panel-title {
+    font-size: 1rem;
+  }
+  .six-great-principles {
+    font-size: 1rem;
+  }
+  .master {
+    font-size: .8rem;
+  }
+  .dalai {
+    font-size: .8rem;
+  }
+  .announcements-images {
+    width: 75%;
+    height: 75%;
+  }
+  .announcements-title, .schedule-title {
+    font-size: 35px;
+  }
+  .content {
+    font-size: .9rem;
+  }
+  .locations-container {
+    font-size: 1rem;
+    justify-content: space-evenly;
+  }
 }


### PR DESCRIPTION
# Some tasks to review: 

- [ ] Media Queries at 475px and 835px. 
- [x] The master and dalai class are in Times New Roman, which overrides the DM Sans font
- [x] Locations container does not have each location class spaced evenly
- [x] The announcements and schedule containers have padding between the separator-top, but not the announcements :0
- [x] The Overflow Issue has been fixed

The locations and Six-Great Principles are not displayed in the phone media query, but a navigation menu could solve that. 